### PR TITLE
Add bounding box for geocoder

### DIFF
--- a/script.js
+++ b/script.js
@@ -16,7 +16,14 @@ new L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png'
 }).addTo(map);
 
 const search = new GeoSearch.GeoSearchControl({
-  provider: new GeoSearch.OpenStreetMapProvider(),
+  provider: new GeoSearch.OpenStreetMapProvider({
+    params: { // See https://nominatim.org/release-docs/develop/api/Search/#parameters for all options
+      'accept-language': 'en',
+      'countrycodes': 'us',
+      'viewbox': '-73.8,40.5,-71.7,42.1', // roughly CT boundaries
+      'bounded': 1
+    }
+  }),
   style: 'bar', // default: button
   searchLabel: 'Search address',
   position: 'topright',


### PR DESCRIPTION
Hi @JackDougherty 

The code adds a CT bounding box restriction to geocoded results for the OSM/Nominatim provider.

It looks like Esri is not quite customisable - see https://github.com/smeijer/leaflet-geosearch/issues/196 - so if you definitely want to use Esri, the best way forward would be to switch to [`esri-leaflet-geocoder`](https://github.com/Esri/esri-leaflet-geocoder).